### PR TITLE
Bug fix for include_short_description

### DIFF
--- a/pyoctopart/octopart.py
+++ b/pyoctopart/octopart.py
@@ -212,7 +212,8 @@ class OctopartManufacturer(object):
 
 class OctopartPart(object):
     @classmethod
-    def includes(include_short_description: bool = False,
+    def includes(cls,
+                 include_short_description: bool = False,
                  include_datasheets: bool = False,
                  include_compliance_documents: bool = False,
                  include_descriptions: bool = False,


### PR DESCRIPTION
Running parts_match with include_short_description=True returned an error.
